### PR TITLE
Adding logic to test if user is assigned to course

### DIFF
--- a/lib/lessonly/resource/user.rb
+++ b/lib/lessonly/resource/user.rb
@@ -1,4 +1,7 @@
 module Lessonly
   class User < Resource
+    def assigned_to?(course)
+      course.assignments.map(&:assignee_id).include?(id)
+    end
   end
 end

--- a/lib/lessonly/version.rb
+++ b/lib/lessonly/version.rb
@@ -1,3 +1,3 @@
 module Lessonly
-  VERSION = '0.0.1'
+  VERSION = '0.1.0'
 end

--- a/spec/course_spec.rb
+++ b/spec/course_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Lessonly::Course do
-  context '#all' do
+  describe '#all' do
     it 'should return all courses' do
       courses = Lessonly::Course.all
       expect(courses.count).to eq 3
@@ -10,14 +10,14 @@ describe Lessonly::Course do
     end
   end
 
-  context '#find' do
+  describe '#find' do
     it 'should find a single course' do
       course = Lessonly::Course.find(1)
       expect(course.title).to eq 'HIPAA Advanced'
     end
   end
 
-  context '#lessons' do
+  describe '#lessons' do
     it 'should have many lessons' do
       course = Lessonly::Course.find(1)
 
@@ -26,7 +26,7 @@ describe Lessonly::Course do
     end
   end
 
-  context '#assignments' do
+  describe '#assignments' do
     it 'should have many assignments' do
       course = Lessonly::Course.find(1)
       assignments = course.assignments
@@ -43,7 +43,7 @@ describe Lessonly::Course do
     end
   end
 
-  context '#create_assignment' do
+  describe '#create_assignment' do
     it 'should create a user assignment' do
       course = Lessonly::Course.find(1)
       user = Lessonly::User.find(3)
@@ -55,7 +55,7 @@ describe Lessonly::Course do
     end
   end
 
-  context '#destroy_assignment' do
+  describe '#destroy_assignment' do
     it 'should remove a user assignment' do
       course = Lessonly::Course.find(1)
       user = Lessonly::User.find(1)

--- a/spec/group_spec.rb
+++ b/spec/group_spec.rb
@@ -1,21 +1,21 @@
 require 'spec_helper'
 
 describe Lessonly::Group do
-  context '#all' do
+  describe '#all' do
     it 'should return all groups' do
       groups = Lessonly::Group.all
       expect(groups.count).to eq 1
     end
   end
 
-  context '#find' do
+  describe '#find' do
     it 'should find a single group' do
       group = Lessonly::Group.find(1)
       expect(group.name).to eq 'Developers'
     end
   end
 
-  context '#create_membership' do
+  describe '#create_membership' do
     it 'should add a user to the group\'s members' do
       group = Lessonly::Group.find(1)
       user = Lessonly::User.find(3)
@@ -27,7 +27,7 @@ describe Lessonly::Group do
     end
   end
 
-  context '#destroy_membership' do
+  describe '#destroy_membership' do
     it 'should remove a user from the group\'s members' do
       group = Lessonly::Group.find(1)
       user = Lessonly::User.find(1)

--- a/spec/user_spec.rb
+++ b/spec/user_spec.rb
@@ -1,17 +1,33 @@
 require 'spec_helper'
 
 describe Lessonly::User do
-  context '#all' do
+  describe '#all' do
     it 'should return all users' do
       users = Lessonly::User.all
       expect(users.count).to eq 3
     end
   end
 
-  context '#find' do
+  describe '#find' do
     it 'should find a single user' do
       user = Lessonly::User.find(1)
       expect(user.name).to eq 'Chas Ballew'
+    end
+  end
+
+  describe '#assigned_to?' do
+    it 'should return true if user is assigned to course' do
+      user = Lessonly::User.find(1)
+      course = Lessonly::Course.find(1)
+
+      expect(user.assigned_to?(course)).to eq true
+    end
+
+    it 'should return false if user is not assigned to course' do
+      user = Lessonly::User.find(3)
+      course = Lessonly::Course.find(1)
+
+      expect(user.assigned_to?(course)).to eq false
     end
   end
 end


### PR DESCRIPTION
This PR adds a method to check if a user is currently assigned a course.  This is useful for preventing course reassignment which could cause confusion for users already assigned.  There are situations were re-assignment is desirable (remedial training, expired gridiron document) where this check would not be necessary. 
