### PR TITLE
Fix accidental re-assignments during course assignment

### DIFF
--- a/lib/lessonly/resource/course.rb
+++ b/lib/lessonly/resource/course.rb
@@ -14,13 +14,17 @@ module Lessonly
       end
     end
 
-    def create_assignment(user, due_by = 1.year.from_now)
-      self.assignments = assignments.push(
+    def create_assignment(users, due_by = 1.year.from_now)
+      users = [users] unless users.is_a? Array
+
+      new_assignments = users.map do |user|
         Lessonly::Assignment.new(agent, assignee_id: user.id, due_by: due_by)
-      )
+      end
+
+      self.assignments = assignments + new_assignments
 
       client.put "#{href}/assignments",
-                 Resource.new(agent, assignments: assignments)
+                 Resource.new(agent, assignments: new_assignments)
     end
 
     def destroy_assignment(user)

--- a/lib/lessonly/version.rb
+++ b/lib/lessonly/version.rb
@@ -1,3 +1,3 @@
 module Lessonly
-  VERSION = '0.1.0'
+  VERSION = '0.1.1'
 end

--- a/spec/course_spec.rb
+++ b/spec/course_spec.rb
@@ -53,6 +53,18 @@ describe Lessonly::Course do
       expect(course.assignments.map(&:assignee_id)).to include(user.id)
       expect(course.assignments.count).to eq 2
     end
+
+    it 'should accept multiple users' do
+      course = Lessonly::Course.find(1)
+      user3 = Lessonly::User.find(3)
+      user2 = Lessonly::User.find(2)
+
+      course.create_assignment([user3, user2])
+
+      expect(course.assignments.map(&:assignee_id)).to include(user3.id)
+      expect(course.assignments.map(&:assignee_id)).to include(user2.id)
+      expect(course.assignments.count).to eq 3
+    end
   end
 
   describe '#destroy_assignment' do

--- a/spec/support/fixtures/get_users_2.json
+++ b/spec/support/fixtures/get_users_2.json
@@ -1,0 +1,8 @@
+{
+  "type": "user",
+  "id": 2,
+  "email": "skylar@aptible.com",
+  "name": "Skylar Anderson",
+  "role": "admin",
+  "custom_user_field_data": [ ]
+}


### PR DESCRIPTION
This change updates course creation to accept an array of users and to only include new assignments in the update payload.

Thanks @armilam
