### PR TITLE
Remove pry reference and bump version

### DIFF
--- a/lib/lessonly/response.rb
+++ b/lib/lessonly/response.rb
@@ -1,6 +1,5 @@
 require 'logger'
 require 'lessonly/exceptions'
-require 'pry'
 
 module Sawyer
   class Response

--- a/lib/lessonly/version.rb
+++ b/lib/lessonly/version.rb
@@ -1,3 +1,3 @@
 module Lessonly
-  VERSION = '0.1.1'
+  VERSION = '0.1.2'
 end


### PR DESCRIPTION
This causes production environments (e.g., set up w/ `bundle install --without development test`) to fail with:

```
LoadError: cannot load such file -- pry
```
